### PR TITLE
 修复 wepy 抛出「不存在 code.match 方法」的错误

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ export default class {
 
   apply(op) {
     const { code, file } = op;
-    if (code && !/app\.js/.test(file)) {
+    if (code && typeof code === 'string' && !/app\.js/.test(file)) {
       const reg = /(\.{0,2}\/)+(\w+\/)+(\S+)\.(png|jpg|gif|jpeg)/gi;
       const imgPaths = code.match(reg) || [];
       imgPaths.map(imgPath => {


### PR DESCRIPTION
当 file 是图片时，此时 code 是二进制对象，不存在 code.match 方法，wepy 会抛出一个警告